### PR TITLE
ci: adds author info via shared autorc

### DIFF
--- a/.autorc
+++ b/.autorc
@@ -1,0 +1,3 @@
+{
+  "extends": "@artsy"
+}

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "registry": "https://registry.npmjs.org"
   },
   "devDependencies": {
+    "@artsy/auto-config": "^1.2.0",
     "@types/jest": "^29.2.4",
     "@types/md5": "^2.3.2",
     "@types/qs": "^6.9.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,6 +10,11 @@
     "@jridgewell/gen-mapping" "^0.1.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
+"@artsy/auto-config@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@artsy/auto-config/-/auto-config-1.2.0.tgz#62a237ca3a058f1b91e5b8a12abebae0ddc5bd2f"
+  integrity sha512-6zGlvqELl4XhqMajJxfgHaY3m5YhZK5FwkxlouJKSb0Su301bzXaPUxKjzj9X147YHJUyrRLSAruzVtj1Gr42Q==
+
 "@auto-it/bot-list@10.37.6":
   version "10.37.6"
   resolved "https://registry.yarnpkg.com/@auto-it/bot-list/-/bot-list-10.37.6.tgz#3ca9380a44b9c8d33b2088b8fed2c2ffc79c91ed"


### PR DESCRIPTION
Interesting that it was able to publish the canary but not the normal version without the author info.