### PR TITLE
feat: add cache policy param to passthrough to gemini

### DIFF
--- a/src/services.ts
+++ b/src/services.ts
@@ -12,6 +12,7 @@ export type ResizeOptions = {
   width?: number;
   height?: number;
   quality?: number;
+  cachePolicy?: string;
 };
 
 export type ServiceConfigurations = {
@@ -30,7 +31,7 @@ export type ImageService = { exec: ResizeExec };
 
 export const validateResizeOptions = (
   mode: ResizeMode,
-  { width, height }: ResizeOptions
+  { width, height, cachePolicy }: ResizeOptions
 ) => {
   if (mode === "crop" && (!width || !height)) {
     console.warn("`crop`requires both `width` and `height`");

--- a/src/services/gemini.ts
+++ b/src/services/gemini.ts
@@ -10,8 +10,8 @@ export type Gemini = {
 };
 
 export const gemini = (config: Gemini): ResizeExec => {
-  return (mode, src, { width, height, quality = DEFAULT_IMG_QUALITY }) => {
-    if (!validateResizeOptions(mode, { width, height })) return src;
+  return (mode, src, { width, height, quality = DEFAULT_IMG_QUALITY, cachePolicy }) => {
+    if (!validateResizeOptions(mode, { width, height, cachePolicy})) return src;
 
     let resizeTo: "width" | "height" | "fit" | "fill";
 
@@ -42,6 +42,7 @@ export const gemini = (config: Gemini): ResizeExec => {
       src,
       width,
       quality,
+      cache_policy: cachePolicy,
     };
 
     const query = stringify(params);


### PR DESCRIPTION
adds a param cachePolicy, only one possible value at the moment to passthrough to gemini.

In order to support: 
https://github.com/artsy/metaphysics/pull/7431
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.1.2--canary.26.151.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @artsy/img@1.1.2--canary.26.151.0
  # or 
  yarn add @artsy/img@1.1.2--canary.26.151.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
