### PR TITLE
chore: add link-pr-to-notion workflow

### DIFF
--- a/.github/workflows/link-pr-to-notion.yml
+++ b/.github/workflows/link-pr-to-notion.yml
@@ -1,0 +1,10 @@
+name: Link PR to Notion
+on:
+  pull_request:
+    types: [opened, edited]
+jobs:
+  link:
+    uses: artsy/duchamp/.github/workflows/link-pr-to-notion.yml@main
+    secrets:
+      notion-token: ${{ secrets.NOTION_TOKEN }}
+      root-page-id: ${{ secrets.NOTION_ROOT_PAGE_ID }}


### PR DESCRIPTION
The type of this PR is: **CHORE**

### Description

- adds the link-pr-to-notion GHA workflow

This PR resolves [DI-235](https://www.notion.so/34ccab0764a081da8250ee109b71a720)